### PR TITLE
Replace home page with work-in-progress placeholder

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,10 +6,9 @@ export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center px-4">
       <div className="max-w-md text-center">
-        <h1 className="mb-4 text-2xl font-bold">Chptr</h1>
+        <h1 className="mb-4 font-lora text-2xl font-medium">Chptr</h1>
         <p className="mb-8 text-muted-foreground">
-          This page is a work in progress. Check back soon — or head to login to
-          get started.
+          This page is a work in progress.
         </p>
         <Button asChild className="w-full py-2 text-sm font-medium">
           <Link href="/login">Go to login</Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,55 +1,20 @@
 import Link from "next/link";
 
-import { LatestPost } from "~/app/_components/post";
-import { api, HydrateClient } from "~/trpc/server";
-// import { ProfileForm } from "./_components/ex-form";
+import { Button } from "~/app/_components/button";
 
-export default async function Home() {
-  const hello = await api.post.hello({ text: "from tRPC" });
-
-  void api.post.getLatest.prefetch();
-
+export default function Home() {
   return (
-    <HydrateClient>
-      {/* <ProfileForm /> */}
-      <main className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-[#2e026d] to-[#15162c] text-white">
-        <div className="container flex flex-col items-center justify-center gap-12 px-4 py-16">
-          <h1 className="text-5xl font-extrabold tracking-tight sm:text-[5rem]">
-            Create <span className="text-[hsl(280,100%,70%)]">T3</span> App
-          </h1>
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:gap-8">
-            <Link
-              className="flex max-w-xs flex-col gap-4 rounded-xl bg-white/10 p-4 hover:bg-white/20"
-              href="https://create.t3.gg/en/usage/first-steps"
-              target="_blank"
-            >
-              <h3 className="text-2xl font-bold">First Steps →</h3>
-              <div className="text-lg">
-                Just the basics - Everything you need to know to set up your
-                database and authentication.
-              </div>
-            </Link>
-            <Link
-              className="flex max-w-xs flex-col gap-4 rounded-xl bg-white/10 p-4 hover:bg-white/20"
-              href="https://create.t3.gg/en/introduction"
-              target="_blank"
-            >
-              <h3 className="text-2xl font-bold">Documentation →</h3>
-              <div className="text-lg">
-                Learn more about Create T3 App, the libraries it uses, and how
-                to deploy it.
-              </div>
-            </Link>
-          </div>
-          <div className="flex flex-col items-center gap-2">
-            <p className="text-2xl text-white">
-              {hello ? hello.greeting : "Loading tRPC query..."}
-            </p>
-          </div>
-
-          <LatestPost />
-        </div>
-      </main>
-    </HydrateClient>
+    <main className="flex min-h-screen flex-col items-center justify-center px-4">
+      <div className="max-w-md text-center">
+        <h1 className="mb-4 text-2xl font-bold">Chptr</h1>
+        <p className="mb-8 text-muted-foreground">
+          This page is a work in progress. Check back soon — or head to login to
+          get started.
+        </p>
+        <Button asChild className="w-full py-2 text-sm font-medium">
+          <Link href="/login">Go to login</Link>
+        </Button>
+      </div>
+    </main>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replaces the Create T3 App starter home page with a simple work-in-progress placeholder
- Keeps the same centered layout, typography, and button styling used on login/welcome
- Adds a primary CTA linking to `/login`

## Test plan
- [ ] Visit `/` and confirm the WIP message and Chptr branding render
- [ ] Confirm the “Go to login” button navigates to `/login`
- [ ] Spot-check light and dark theme appearance
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3044491f-ed1e-4196-a88c-5bf6d14837e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3044491f-ed1e-4196-a88c-5bf6d14837e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

