### PR TITLE
Fix mobile header drifting under the safe area after keyboard dismiss.

### DIFF
--- a/src/app/_components/drawer.tsx
+++ b/src/app/_components/drawer.tsx
@@ -11,28 +11,32 @@ const Drawer = ({
   noBodyStyles = true,
   fixed = true,
   repositionInputs = true,
+  chromeSampler = true,
   open,
   onOpenChange,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Root>) => {
+}: React.ComponentProps<typeof DrawerPrimitive.Root> & {
+  /** Tint iOS status-bar chrome to match the scrim (mobile). Default true. */
+  chromeSampler?: boolean;
+}) => {
   React.useEffect(() => {
     if (typeof open !== "boolean") return;
 
-    setOverlayOpen(open);
+    setOverlayOpen(open, { chromeSampler });
 
     return () => {
       if (open) {
         setOverlayOpen(false);
       }
     };
-  }, [open]);
+  }, [open, chromeSampler]);
 
   const handleOpenChange = React.useCallback(
     (next: boolean) => {
-      setOverlayOpen(next);
+      setOverlayOpen(next, { chromeSampler });
       onOpenChange?.(next);
     },
-    [onOpenChange],
+    [chromeSampler, onOpenChange],
   );
 
   return (

--- a/src/app/_components/header.tsx
+++ b/src/app/_components/header.tsx
@@ -14,7 +14,7 @@ export function Header() {
   return (
     <header
       data-app-header
-      className="z-10 flex h-12 shrink-0 items-center justify-between gap-2 bg-background px-4 max-md:absolute max-md:inset-x-0 max-md:top-0 md:relative md:rounded-t-2xl"
+      className="z-10 flex h-12 shrink-0 items-center justify-between gap-2 bg-background px-4 max-md:fixed max-md:inset-x-0 max-md:top-0 md:relative md:rounded-t-2xl"
     >
       <div className="flex min-w-0 flex-1 items-center gap-2">
         <SidebarTrigger />

--- a/src/app/_components/overlay-backdrop.ts
+++ b/src/app/_components/overlay-backdrop.ts
@@ -100,6 +100,7 @@ function clearOverlayChrome() {
   if (isOverlayDimmed()) return;
 
   delete document.documentElement.dataset.overlayOpen;
+  delete document.documentElement.dataset.drawerChromeSampler;
   setDefaultThemeColors();
 }
 
@@ -116,15 +117,33 @@ export function refreshOverlayChrome() {
   clearOverlayChrome();
 }
 
-export function setOverlayOpen(open: boolean) {
+export type SetOverlayOpenOptions = {
+  /**
+   * iOS 26 status-bar chrome sampler (fixed top strip + transparent header).
+   * Defaults to true for drawers; set false to skip.
+   */
+  chromeSampler?: boolean;
+};
+
+export function setOverlayOpen(
+  open: boolean,
+  options: SetOverlayOpenOptions = {},
+) {
   const html = document.documentElement;
+  const chromeSampler = options.chromeSampler !== false;
 
   if (open) {
     html.dataset.drawerOverlay = "";
+    if (chromeSampler) {
+      html.dataset.drawerChromeSampler = "";
+    } else {
+      delete html.dataset.drawerChromeSampler;
+    }
     refreshOverlayChrome();
     return;
   }
 
   delete html.dataset.drawerOverlay;
+  delete html.dataset.drawerChromeSampler;
   refreshOverlayChrome();
 }

--- a/src/app/_components/overlay-backdrop.ts
+++ b/src/app/_components/overlay-backdrop.ts
@@ -54,26 +54,39 @@ function forEachThemeColorMeta(
   });
 }
 
-function setDefaultThemeColors() {
+function activeThemeScheme(): Exclude<ThemeColorScheme, "default"> {
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
+}
+
+/**
+ * Safari often ignores content updates on media-conditioned theme-color metas.
+ * Keep those in sync, and also stamp a media-less meta Safari reliably repaints.
+ */
+function setThemeColors(colors: Record<ThemeColorScheme, string>) {
   forEachThemeColorMeta((meta, scheme) => {
     meta.content =
-      scheme === "default"
-        ? document.documentElement.classList.contains("dark")
-          ? DEFAULT_THEME_COLORS.dark
-          : DEFAULT_THEME_COLORS.light
-        : DEFAULT_THEME_COLORS[scheme];
+      scheme === "default" ? colors[activeThemeScheme()] : colors[scheme];
   });
+
+  let active = document.querySelector<HTMLMetaElement>(
+    'meta[name="theme-color"]:not([media])',
+  );
+
+  if (!active) {
+    active = document.createElement("meta");
+    active.name = "theme-color";
+    document.head.appendChild(active);
+  }
+
+  active.content = colors[activeThemeScheme()];
+}
+
+function setDefaultThemeColors() {
+  setThemeColors(DEFAULT_THEME_COLORS);
 }
 
 function setOverlayThemeColors() {
-  forEachThemeColorMeta((meta, scheme) => {
-    meta.content =
-      scheme === "default"
-        ? document.documentElement.classList.contains("dark")
-          ? OVERLAY_THEME_COLORS.dark
-          : OVERLAY_THEME_COLORS.light
-        : OVERLAY_THEME_COLORS[scheme];
-  });
+  setThemeColors(OVERLAY_THEME_COLORS);
 }
 
 function isOverlayDimmed() {

--- a/src/app/_components/overlay-theme-sync.tsx
+++ b/src/app/_components/overlay-theme-sync.tsx
@@ -6,9 +6,8 @@ import { refreshOverlayChrome } from "./overlay-backdrop";
 /**
  * Sync safe-area chrome when Radix sets body[data-scroll-locked] on dialogs/sheets.
  *
- * iOS 26 Safari ignores theme-color and samples the nearest fixed/sticky background
- * at the viewport edge. The opaque sampler below is what actually tints the status bar
- * while overlays are open (see globals.css).
+ * The fixed sampler below only paints while a drawer sets data-drawer-chrome-sampler
+ * (Drawer chromeSampler prop). Sidebar sheets and other overlays leave it hidden.
  */
 export function OverlayThemeSync() {
   useEffect(() => {

--- a/src/app/_components/overlay-theme-sync.tsx
+++ b/src/app/_components/overlay-theme-sync.tsx
@@ -3,7 +3,13 @@
 import { useEffect } from "react";
 import { refreshOverlayChrome } from "./overlay-backdrop";
 
-/** Sync safe-area chrome when Radix sets body[data-scroll-locked] on dialogs/sheets. */
+/**
+ * Sync safe-area chrome when Radix sets body[data-scroll-locked] on dialogs/sheets.
+ *
+ * iOS 26 Safari ignores theme-color and samples the nearest fixed/sticky background
+ * at the viewport edge. The opaque sampler below is what actually tints the status bar
+ * while overlays are open (see globals.css).
+ */
 export function OverlayThemeSync() {
   useEffect(() => {
     refreshOverlayChrome();
@@ -20,5 +26,7 @@ export function OverlayThemeSync() {
     return () => observer.disconnect();
   }, []);
 
-  return null;
+  return (
+    <div data-overlay-chrome-sampler aria-hidden="true" />
+  );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -111,18 +111,9 @@ body {
     background-color: hsl(var(--background));
   }
 
-  html[data-overlay-open] {
-    background-color: color-mix(in srgb, black 80%, hsl(var(--background)));
-  }
-
-  /* Safe-area chrome tint via theme-color (overlay-backdrop.ts). */
-  /* Keep app chrome below portaled scrim (fixed header can otherwise paint above overlays on iOS). */
+  /* Keep app chrome below portaled scrim. */
   html[data-overlay-open] .group\/sidebar-wrapper {
     position: relative;
-    z-index: 0;
-  }
-
-  html[data-overlay-open] [data-app-header] {
     z-index: 0;
   }
 
@@ -147,6 +138,51 @@ body {
       -webkit-transform: translate3d(0, 0, 0);
       transform: translate3d(0, 0, 0);
     }
+  }
+}
+
+/*
+ * Overlay safe-area fill — unlayered so it wins over Tailwind bg-* utilities.
+ *
+ * iOS 26 Safari ignores theme-color and samples the nearest fixed/sticky background
+ * at the viewport edge. Our fixed white header is what kept the status bar white.
+ * While overlays are open: clear the header fill so the scrim shows through, and show
+ * a thin fixed top sampler in the overlay chrome color for Safari to sample.
+ */
+html[data-overlay-open] {
+  background-color: #333333;
+}
+
+html.dark[data-overlay-open] {
+  background-color: #050505;
+}
+
+/* display:none when idle — opacity:0 still gets sampled by Safari 26. */
+[data-overlay-chrome-sampler] {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  html[data-overlay-open] [data-app-header] {
+    background-color: transparent;
+  }
+
+  [data-overlay-chrome-sampler] {
+    position: fixed;
+    inset-inline: 0;
+    top: 0;
+    z-index: 45;
+    height: 12px;
+    pointer-events: none;
+    background-color: #333333;
+  }
+
+  html[data-overlay-open] [data-overlay-chrome-sampler] {
+    display: block;
+  }
+
+  html.dark[data-overlay-open] [data-overlay-chrome-sampler] {
+    background-color: #050505;
   }
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -142,18 +142,17 @@ body {
 }
 
 /*
- * Overlay safe-area fill — unlayered so it wins over Tailwind bg-* utilities.
+ * Drawer status-bar chrome — unlayered so it wins over Tailwind bg-* utilities.
  *
  * iOS 26 Safari ignores theme-color and samples the nearest fixed/sticky background
- * at the viewport edge. Our fixed white header is what kept the status bar white.
- * While overlays are open: clear the header fill so the scrim shows through, and show
- * a thin fixed top sampler in the overlay chrome color for Safari to sample.
+ * at the viewport edge. Enabled only while a drawer sets data-drawer-chrome-sampler
+ * (see Drawer chromeSampler prop) — not for sidebar sheets / other overlays.
  */
-html[data-overlay-open] {
+html[data-drawer-chrome-sampler] {
   background-color: #333333;
 }
 
-html.dark[data-overlay-open] {
+html.dark[data-drawer-chrome-sampler] {
   background-color: #050505;
 }
 
@@ -163,7 +162,7 @@ html.dark[data-overlay-open] {
 }
 
 @media (max-width: 767px) {
-  html[data-overlay-open] [data-app-header] {
+  html[data-drawer-chrome-sampler] [data-app-header] {
     background-color: transparent;
   }
 
@@ -177,11 +176,11 @@ html.dark[data-overlay-open] {
     background-color: #333333;
   }
 
-  html[data-overlay-open] [data-overlay-chrome-sampler] {
+  html[data-drawer-chrome-sampler] [data-overlay-chrome-sampler] {
     display: block;
   }
 
-  html.dark[data-overlay-open] [data-overlay-chrome-sampler] {
+  html.dark[data-drawer-chrome-sampler] [data-overlay-chrome-sampler] {
     background-color: #050505;
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -116,7 +116,7 @@ body {
   }
 
   /* Safe-area chrome tint via theme-color (overlay-backdrop.ts). */
-  /* Keep app chrome below portaled scrim (iOS paints absolute header above fixed overlays). */
+  /* Keep app chrome below portaled scrim (fixed header can otherwise paint above overlays on iOS). */
   html[data-overlay-open] .group\/sidebar-wrapper {
     position: relative;
     z-index: 0;


### PR DESCRIPTION
Pin the app header with fixed positioning on mobile so iOS keyboard scroll no longer leaves it stuck mid-safe-area.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile header behavior by keeping the header fixed at the top of the screen during page scrolling.
  * Ensured overlay layering behaves correctly with fixed headers on iOS devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->